### PR TITLE
chore: fix rimraf command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "npm run build && ts-node projects/build.ts",
     "build": "npm run rimraf && tsc",
-    "rimraf": "node -e \"require('fs').rmdirSync('dist', { recursive: true })\"",
+    "rimraf": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "release": "standard-version --skip.tag",
     "release:major": "npm run release -- --release-as major",
     "release:minor": "npm run release -- --release-as minor",


### PR DESCRIPTION
<!--

Thank you for your contirubtion! 👍

-->

## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [x] Maintenance
- [ ] Documentation

## Changes

- `rmdirSync` with `recursive` option was deprecated, so replace it with `rmSync`
  - https://github.com/nodejs/node/pull/37302
- When `dist` dir does not exist, this command will throw error, so add `force` option.

## Community note

<!-- Please keep this section. -->

Please upvode with reacting as :+1: to express your agreement.
