### PR TITLE
fix: generate path directly under route groups directory

### DIFF
--- a/projects/nextjs-appdir/app/xxx/(group3)/page.tsx
+++ b/projects/nextjs-appdir/app/xxx/(group3)/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export type OptionalQuery = { hoge: string }
+
+// `onClick`, `href`, and `ref` need to be passed to the DOM element
+// for proper handling
+const MyButton = React.forwardRef(({ onClick, href }, ref) => {
+  return (
+    <a href={href} onClick={onClick} ref={ref}>
+      Click Me
+    </a>
+  )
+})
+
+function Home() {
+  return (
+    <Link href="/about" passHref>
+      <MyButton />
+    </Link>
+  )
+}
+
+export default Home

--- a/projects/nextjs-appdir/app/xxx/(group3)/yyy/page.tsx
+++ b/projects/nextjs-appdir/app/xxx/(group3)/yyy/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export type OptionalQuery = { hoge: string }
+
+// `onClick`, `href`, and `ref` need to be passed to the DOM element
+// for proper handling
+const MyButton = React.forwardRef(({ onClick, href }, ref) => {
+  return (
+    <a href={href} onClick={onClick} ref={ref}>
+      Click Me
+    </a>
+  )
+})
+
+function Home() {
+  return (
+    <Link href="/about" passHref>
+      <MyButton />
+    </Link>
+  )
+}
+
+export default Home

--- a/projects/nextjs-appdir/lib/$path.ts
+++ b/projects/nextjs-appdir/lib/$path.ts
@@ -1,6 +1,8 @@
 import type { Query as Query_1j04kwd } from '../app/page';
 import type { OptionalQuery as OptionalQuery_1qd20e9 } from '../app/(group1)/[pid]/page';
 import type { Query as Query_g05ywg } from '../app/(group1)/blog/[...slug]/page';
+import type { OptionalQuery as OptionalQuery_s8tu8q } from '../app/xxx/(group3)/page';
+import type { OptionalQuery as OptionalQuery_ywjxi8 } from '../app/xxx/(group3)/yyy/page';
 import type { OptionalQuery as OptionalQuery_19vdpqy } from '../pages/children/[pid]';
 import type { Query as Query_1rrk9o7 } from '../pages/children/blog/[...slug]';
 
@@ -55,6 +57,12 @@ export const pagesPath = {
       })
     }
   }),
+  "xxx": {
+    "yyy": {
+      $url: (url?: { query?: OptionalQuery_ywjxi8, hash?: string }) => ({ pathname: '/xxx/yyy' as const, query: url?.query, hash: url?.hash, path: `/xxx/yyy${buildSuffix(url)}` })
+    },
+    $url: (url?: { query?: OptionalQuery_s8tu8q, hash?: string }) => ({ pathname: '/xxx' as const, query: url?.query, hash: url?.hash, path: `/xxx${buildSuffix(url)}` })
+  },
   $url: (url: { query: Query_1j04kwd, hash?: string }) => ({ pathname: '/' as const, query: url.query, hash: url.hash, path: `/${buildSuffix(url)}` }),
   "children": {
     "%E6%97%A5%E6%9C%AC%E8%AA%9E": {

--- a/projects/nextjs-appdir/out/lib/basic/$path.ts
+++ b/projects/nextjs-appdir/out/lib/basic/$path.ts
@@ -1,6 +1,8 @@
 import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
+import type { OptionalQuery as OptionalQuery_1cjq374 } from '../../../app/xxx/(group3)/page';
+import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(group3)/yyy/page';
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
@@ -52,6 +54,12 @@ export const pagesPath = {
       })
     }
   }),
+  "xxx": {
+    "yyy": {
+      $url: (url?: { query?: OptionalQuery_75amui, hash?: string }) => ({ pathname: '/xxx/yyy' as const, query: url?.query, hash: url?.hash, path: `/xxx/yyy${buildSuffix(url)}` })
+    },
+    $url: (url?: { query?: OptionalQuery_1cjq374, hash?: string }) => ({ pathname: '/xxx' as const, query: url?.query, hash: url?.hash, path: `/xxx${buildSuffix(url)}` })
+  },
   $url: (url: { query: Query_1yksaqv, hash?: string }) => ({ pathname: '/' as const, query: url.query, hash: url.hash, path: `/${buildSuffix(url)}` }),
   "children": {
     "%E6%97%A5%E6%9C%AC%E8%AA%9E": {

--- a/projects/nextjs-appdir/out/lib/ignore/$path.ts
+++ b/projects/nextjs-appdir/out/lib/ignore/$path.ts
@@ -1,6 +1,8 @@
 import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
+import type { OptionalQuery as OptionalQuery_1cjq374 } from '../../../app/xxx/(group3)/page';
+import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(group3)/yyy/page';
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
@@ -52,6 +54,12 @@ export const pagesPath = {
       })
     }
   }),
+  "xxx": {
+    "yyy": {
+      $url: (url?: { query?: OptionalQuery_75amui, hash?: string }) => ({ pathname: '/xxx/yyy' as const, query: url?.query, hash: url?.hash, path: `/xxx/yyy${buildSuffix(url)}` })
+    },
+    $url: (url?: { query?: OptionalQuery_1cjq374, hash?: string }) => ({ pathname: '/xxx' as const, query: url?.query, hash: url?.hash, path: `/xxx${buildSuffix(url)}` })
+  },
   $url: (url: { query: Query_1yksaqv, hash?: string }) => ({ pathname: '/' as const, query: url.query, hash: url.hash, path: `/${buildSuffix(url)}` }),
   "children": {
     "%E6%97%A5%E6%9C%AC%E8%AA%9E": {

--- a/projects/nextjs-appdir/out/lib/static/$path.ts
+++ b/projects/nextjs-appdir/out/lib/static/$path.ts
@@ -1,6 +1,8 @@
 import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
+import type { OptionalQuery as OptionalQuery_1cjq374 } from '../../../app/xxx/(group3)/page';
+import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(group3)/yyy/page';
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
@@ -55,6 +57,12 @@ export const pagesPath = {
       })
     }
   }),
+  "xxx": {
+    "yyy": {
+      $url: (url?: { query?: OptionalQuery_75amui, hash?: string }) => ({ pathname: '/xxx/yyy' as const, query: url?.query, hash: url?.hash, path: `/xxx/yyy${buildSuffix(url)}` })
+    },
+    $url: (url?: { query?: OptionalQuery_1cjq374, hash?: string }) => ({ pathname: '/xxx' as const, query: url?.query, hash: url?.hash, path: `/xxx${buildSuffix(url)}` })
+  },
   $url: (url: { query: Query_1yksaqv, hash?: string }) => ({ pathname: '/' as const, query: url.query, hash: url.hash, path: `/${buildSuffix(url)}` }),
   "children": {
     "%E6%97%A5%E6%9C%AC%E8%AA%9E": {

--- a/src/nextjs/parseAppDir.ts
+++ b/src/nextjs/parseAppDir.ts
@@ -65,7 +65,21 @@ export const parseAppDir = (
         const newSlugs = [...slugs];
         const target = path.posix.join(targetDir, file);
         if (file.startsWith('(') && file.endsWith(')')) {
-          return createPathObjString(target, indent.slice(2), url, newSlugs, '<% props %>');
+          const indexFile = fs.readdirSync(target).find(name => pageFileNames.includes(name));
+          return createPathObjString(
+            target,
+            indent.slice(2),
+            url,
+            newSlugs,
+            '<% props %>',
+            indexFile &&
+              createMethods(
+                indent.slice(2),
+                getImportName(path.posix.join(target, indexFile)),
+                newSlugs,
+                url
+              )
+          );
         }
 
         const newUrl = `${url}/${file}`;


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [x] Bug fixes
  - resolves #185 
  - resolves #186
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

- Fixed to generate paths for page.tsx in the directory directly under the route groups.

## Additional context

- To test the PR, `app/xxx/(group3)/page.tsx` and `app/xxx/(group3)/yyyy/page.tsx` are added.

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
