### PR TITLE
Exclude parallel route segments (@) from URL paths

### DIFF
--- a/src/nextjs/parseAppDir.ts
+++ b/src/nextjs/parseAppDir.ts
@@ -82,7 +82,9 @@ export const parseAppDir = (
           );
         }
 
-        const newUrl = `${url}/${file}`;
+        const isParallelRoute = file.startsWith('@');
+        const newUrl = isParallelRoute ? url : `${url}/${file}`;
+
         let valFn = `${indent}${JSON.stringify(
           replaceWithUnderscore(file)
         )}: {\n<% next %>\n${indent}}`;


### PR DESCRIPTION
# Types of changes
- [x] Bug fixes
- [ ] Features
- [ ] Maintenance
- [ ] Documentation

resolves Support for Next.js parallel routes #XXX

# Changes
Added support for Next.js parallel routes by excluding `@` segments from URL paths.
Next.jsのパラレルルートに対応し、URLパスから`@`セグメントを除外するように変更

# Additional context
[ja]
Next.jsのパラレルルート（例：@modal, @auth）がURLパスに含まれてしまう問題を修正しました。
例えば、`domain/@modal/modal-a`のようなパスが`domain/modal-a`として正しく出力されるようになります。

[en]
Fixed an issue where Next.js parallel route segments (e.g., @modal, @auth) were incorrectly included in URL paths.
For example, paths like `domain/@modal/modal-a` will now correctly output as `domain/modal-a`.

Reference: See Parallel Routes documentation: https://nextjs.org/docs/app/building-your-application/routing/parallel-routes

# Community note
Please upvote with reacting as 👍 to express your agreement.