### PR TITLE
Enhance query param types for Next.js 

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,28 +219,6 @@ export default () => {
 };
 ```
 
-<a id="Convert query types"></a>
-
-### Convert query types
-
-```tsx
-import type { ToNextSearchParams } from "../lib/$path";
-
-export type Query = {
-  limit: number;
-  productIds: number[];
-};
-
-type PageProps = {
-  searchParams: ToNextSearchParams<Query>;
-}
-// {
-//   limit: number;          // number -> string
-//   productIds: number[];   // number[] -> string[]
-// }
-```
-
-
 <a id="Generate-static-files-path"></a>
 
 ## Generate static files path

--- a/README.md
+++ b/README.md
@@ -219,6 +219,28 @@ export default () => {
 };
 ```
 
+<a id="Convert query types"></a>
+
+### Convert query types
+
+```tsx
+import type { ToNextSearchParams } from "../lib/$path";
+
+export type Query = {
+  limit: number;
+  productIds: number[];
+};
+
+type PageProps = {
+  searchParams: ToNextSearchParams<Query>;
+}
+// {
+//   limit: number;          // number -> string
+//   productIds: number[];   // number[] -> string[]
+// }
+```
+
+
 <a id="Generate-static-files-path"></a>
 
 ## Generate static files path

--- a/projects/nextjs-appdir/lib/$path.ts
+++ b/projects/nextjs-appdir/lib/$path.ts
@@ -6,12 +6,6 @@ import type { OptionalQuery as OptionalQuery_ywjxi8 } from '../app/xxx/(group3)/
 import type { OptionalQuery as OptionalQuery_19vdpqy } from '../pages/children/[pid]';
 import type { Query as Query_1rrk9o7 } from '../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-appdir/lib/$path.ts
+++ b/projects/nextjs-appdir/lib/$path.ts
@@ -6,11 +6,37 @@ import type { OptionalQuery as OptionalQuery_ywjxi8 } from '../app/xxx/(group3)/
 import type { OptionalQuery as OptionalQuery_19vdpqy } from '../pages/children/[pid]';
 import type { Query as Query_1rrk9o7 } from '../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-appdir/out/lib/basic/$path.ts
+++ b/projects/nextjs-appdir/out/lib/basic/$path.ts
@@ -6,11 +6,37 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-appdir/out/lib/basic/$path.ts
+++ b/projects/nextjs-appdir/out/lib/basic/$path.ts
@@ -6,12 +6,6 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-appdir/out/lib/ignore/$path.ts
+++ b/projects/nextjs-appdir/out/lib/ignore/$path.ts
@@ -6,11 +6,37 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-appdir/out/lib/ignore/$path.ts
+++ b/projects/nextjs-appdir/out/lib/ignore/$path.ts
@@ -6,12 +6,6 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-appdir/out/lib/static/$path.ts
+++ b/projects/nextjs-appdir/out/lib/static/$path.ts
@@ -6,11 +6,37 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-appdir/out/lib/static/$path.ts
+++ b/projects/nextjs-appdir/out/lib/static/$path.ts
@@ -6,12 +6,6 @@ import type { OptionalQuery as OptionalQuery_75amui } from '../../../app/xxx/(gr
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-src-appdir/src/out/lib/basic/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/basic/$path.ts
@@ -2,11 +2,37 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-src-appdir/src/out/lib/basic/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/basic/$path.ts
@@ -2,12 +2,6 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-src-appdir/src/out/lib/ignore/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/ignore/$path.ts
@@ -2,11 +2,37 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-src-appdir/src/out/lib/ignore/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/ignore/$path.ts
@@ -2,12 +2,6 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-src-appdir/src/out/lib/static/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/static/$path.ts
@@ -2,11 +2,37 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-src-appdir/src/out/lib/static/$path.ts
+++ b/projects/nextjs-src-appdir/src/out/lib/static/$path.ts
@@ -2,12 +2,6 @@ import type { Query as Query_1yksaqv } from '../../../app/page';
 import type { OptionalQuery as OptionalQuery_a6l6vr } from '../../../app/(group1)/[pid]/page';
 import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]/page';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-src-appdir/src/utils/$path.ts
+++ b/projects/nextjs-src-appdir/src/utils/$path.ts
@@ -2,11 +2,37 @@ import type { Query as Query_1j04kwd } from '../app/page';
 import type { OptionalQuery as OptionalQuery_1qd20e9 } from '../app/(group1)/[pid]/page';
 import type { Query as Query_g05ywg } from '../app/(group1)/blog/[...slug]/page';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-src-appdir/src/utils/$path.ts
+++ b/projects/nextjs-src-appdir/src/utils/$path.ts
@@ -2,12 +2,6 @@ import type { Query as Query_1j04kwd } from '../app/page';
 import type { OptionalQuery as OptionalQuery_1qd20e9 } from '../app/(group1)/[pid]/page';
 import type { Query as Query_g05ywg } from '../app/(group1)/blog/[...slug]/page';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-stable-appdir/lib/$path.ts
+++ b/projects/nextjs-stable-appdir/lib/$path.ts
@@ -4,12 +4,6 @@ import type { Query as Query_g05ywg } from '../app/(group1)/blog/[...slug]/page'
 import type { OptionalQuery as OptionalQuery_19vdpqy } from '../pages/children/[pid]';
 import type { Query as Query_1rrk9o7 } from '../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-stable-appdir/lib/$path.ts
+++ b/projects/nextjs-stable-appdir/lib/$path.ts
@@ -4,11 +4,37 @@ import type { Query as Query_g05ywg } from '../app/(group1)/blog/[...slug]/page'
 import type { OptionalQuery as OptionalQuery_19vdpqy } from '../pages/children/[pid]';
 import type { Query as Query_1rrk9o7 } from '../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-stable-appdir/out/lib/basic/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/basic/$path.ts
@@ -4,12 +4,6 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-stable-appdir/out/lib/basic/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/basic/$path.ts
@@ -4,11 +4,37 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-stable-appdir/out/lib/ignore/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/ignore/$path.ts
@@ -4,12 +4,6 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-stable-appdir/out/lib/ignore/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/ignore/$path.ts
@@ -4,11 +4,37 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/projects/nextjs-stable-appdir/out/lib/static/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/static/$path.ts
@@ -4,12 +4,6 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
 const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string

--- a/projects/nextjs-stable-appdir/out/lib/static/$path.ts
+++ b/projects/nextjs-stable-appdir/out/lib/static/$path.ts
@@ -4,11 +4,37 @@ import type { Query as Query_46sa06 } from '../../../app/(group1)/blog/[...slug]
 import type { OptionalQuery as OptionalQuery_1b52tdg } from '../../../pages/children/[pid]';
 import type { Query as Query_9ixms9 } from '../../../pages/children/blog/[...slug]';
 
-const buildSuffix = (url?: { query?: any, hash?: string }) => {
+type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
+
+export type ToNextSearchParams<T> = {
+  [K in keyof T]: ConvertToSearchParam<T[K]>
+};
+
+const buildSuffix = (url?: {
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+  hash?: string
+}) => {
   const query = url?.query;
   const hash = url?.hash;
+  if (!query && !hash) return '';
+  const search = (() => {
+    if (!query) return '';
 
-  return `${query ? `?${new URLSearchParams(query)}` : ''}${hash ? `#${hash}` : ''}`;
+    const params = new URLSearchParams();
+
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((item) =>
+          params.append(key, String(item))
+        );
+      } else {
+        params.set(key, String(value));
+      }
+    });
+
+    return `?${params.toString()}`;
+  })();
+  return `${search}${hash ? `#${hash}` : ''}`;
 };
 
 export const pagesPath = {

--- a/src/createNextTemplate.ts
+++ b/src/createNextTemplate.ts
@@ -18,13 +18,7 @@ export const createNextTemplate = (
 
   return `${imports.join('\n')}${imports.length ? '\n\n' : ''}${
     appDir
-      ? `type ConvertToSearchParam<T> = T extends unknown[] ? string[] : string;
-
-export type ToNextSearchParams<T> = {
-  [K in keyof T]: ConvertToSearchParam<T[K]>
-};
-
-const buildSuffix = (url?: {
+      ? `const buildSuffix = (url?: {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>,
   hash?: string
 }) => {

--- a/src/createNextTemplate.ts
+++ b/src/createNextTemplate.ts
@@ -6,7 +6,7 @@ export const createNextTemplate = (
   output: string,
   ignorePath: string | undefined,
   appDir: { input: string } | undefined,
-  pageExtensions = ['tsx', 'ts', 'jsx', 'js']
+  pageExtensions = ['tsx', 'ts', 'jsx', 'js'],
 ): string => {
   const appDirData = appDir
     ? parseAppDir(appDir.input, output, ignorePath)


### PR DESCRIPTION
# Types of changes
- [ ] Bug fixes
- [x] Features
  - resolves https://github.com/aspida/pathpida/issues/189
- [ ] Maintenance
- [ ] Documentation

resolves Enhance query parameter type safety #XXX

# Changes
Enhanced query parameter type safety by extending the type system to handle various parameter types and providing type conversion utilities.
クエリパラメータの型安全性を向上させ、様々な型のパラメータを扱えるように拡張し、型変換ユーティリティを提供

# Additional context
[ja]
クエリパラメータの型安全性を向上させる機能を追加しました

1. `buildSuffix`関数の型拡張
   - 従来の`Record<string, string>`から、より柔軟な型定義に拡張
   - `number`、`boolean`、配列型（`string[]`、`number[]`、`boolean[]`）をサポート
   - 全ての値は自動的に適切な文字列形式に変換

2. 型変換ユーティリティの追加
   - `ToNextSearchParams`型を追加し、Next.jsの`searchParams`との型互換性を確保
   - 入力の型を自動的にNext.js互換の型（`string`または`string[]`）に変換

使用例：
```tsx
// 入力の型定義
export type Query = {
  postId: number;  
  isActive: boolean; 
  categoryIds: number[]; 
};

// searchParamsの型として使用
type PageProps = {
  searchParams: ToNextSearchParams<Query>;
}; // => { postId: string; isActive: string; categoryIds: string[]; }
```

[en]
Added features to enhance query parameter type safety

1. Extended `buildSuffix` function types
   - Expanded from `Record<string, string>` to support more flexible type definitions
   - Added support for `number`, `boolean`, and array types (`string[]`, `number[]`, `boolean[]`)
   - All values are automatically converted to appropriate string formats

2. Added type conversion utilities
   - Introduced `ToNextSearchParams` type to ensure compatibility with Next.js `searchParams`
   - Automatically converts input types to Next.js compatible types (`string` or `string[]`)

Usage example:
```tsx
// Input type definition
export type Query = {
  postId: number; 
  isActive: boolean;
  categoryIds: number[];
};

// Use as searchParams type
type PageProps = {
  searchParams: ToNextSearchParams<Query>;
};  // => { postId: string; isActive: string; categoryIds: string[]; }
```